### PR TITLE
added more vehicles

### DIFF
--- a/src/data/travel.csv
+++ b/src/data/travel.csv
@@ -64,10 +64,10 @@ EMOJI,SIZE (in cm),INFO
 🚊,?,Tram
 🚝,3.67m,Monorail
 🚞,?,Mountain Railway
-🚋,?,Tram Car
-🚌,?,Bus
+🚋,14m,Tram Car
+🚌,12m,Bus
 🚍,?,Oncoming Bus
-🚎,?,Trolleybus
+🚎,11m,Trolleybus
 🚐,?,Minibus
 🚑,?,Ambulance
 🚒,?,Fire Engine
@@ -75,13 +75,13 @@ EMOJI,SIZE (in cm),INFO
 🚔,?,Oncoming Police Car
 🚕,?,Taxi
 🚖,?,Oncoming Taxi
-🚗,?,Automobile
+🚗,,Automobile
 🚘,?,Oncoming Automobile
 🚙,?,Sport Utility Vehicle
 🛻,?,Pickup Truck
 🚚,?,Delivery Truck
 🚛,?,Articulated Lorry
-🚜,?,Tractor
+🚜,5m,Tractor
 🏎️,?,Racing Car
 🏍️,?,Motorcycle
 🛵,?,Motor Scooter
@@ -90,7 +90,7 @@ EMOJI,SIZE (in cm),INFO
 🛴,?,Kick Scooter
 🚏,?,Bus Stop
 🛣️,?,Motorway
-🛤️,?,Railway Track
+🛤️,143,Railway Track
 ⛽,?,Fuel Pump
 🚨,?,Police Car Light
 🚥,?,Horizontal Traffic Light
@@ -103,8 +103,8 @@ EMOJI,SIZE (in cm),INFO
 ⛴️,?,Ferry
 🛥️,?,Motor Boat
 🚢,?,Ship
-✈️,?,Airplane
-🛩️,?,Small Airplane
+✈️,30m,Airplane
+🛩️,9m,Small Airplane
 🛫,?,Airplane Departure
 🛬,?,Airplane Arrival
 🪂,?,Parachute
@@ -125,6 +125,6 @@ EMOJI,SIZE (in cm),INFO
 🎑,?,Moon Viewing Ceremony
 💴,?,Yen Banknote
 💵,?,Dollar Banknote
-💶,?,Euro Banknote
+💶,14,Euro Banknote
 💷,?,Pound Banknote
 🗿,4m,Moai


### PR DESCRIPTION
added sizes of these objects:

- tram car - 14m based on https://en.wikipedia.org/wiki/Tatra_T3
- bus - 12m - based on https://en.wikipedia.org/wiki/Solaris_Urbino_12
- tractor - based on sizes of modern John Deer tractor (as found in local dealership manual)
- small airplane - based on https://cs.wikipedia.org/wiki/Cessna_172
- airplane - based on https://en.wikipedia.org/wiki/Boeing_737
- railway track (gauge) - 1435mm
- automobile - 4m - based on https://en.wikipedia.org/wiki/Fiat_Multipla
- trolleybus - 11m - based on https://en.wikipedia.org/wiki/%C5%A0koda_14Tr

note that size of the vehicles is their length