### PR TITLE
You always need a 🍌 for scale

### DIFF
--- a/src/data/objects.csv
+++ b/src/data/objects.csv
@@ -223,3 +223,4 @@ EMOJI,SIZE (in cm),INFO
 ⚱️,?,Funeral Urn
 🪧,?,Placard
 🚰,?,Potable Water
+🍌,19,Banana


### PR DESCRIPTION
Sources:
- https://healthyeating.sfgate.com/portion-size-bananas-7664.html (average banana is 7-8in, 7.5in is 19cm)
- https://knowyourmeme.com/memes/banana-for-scale