### PR TITLE
add otter to the list

### DIFF
--- a/src/data/nature.csv
+++ b/src/data/nature.csv
@@ -67,3 +67,4 @@ EMOJI,SIZE (in cm),INFO
 🎄,?,Christmas Tree
 🌞,139268000000,Sol
 🪰,0.6,Housefly
+🦦,100,Otter


### PR DESCRIPTION
The [otter emoji proposal](https://www.unicode.org/L2/L2018/18093-otter-emoji.pdf) doesn't detail which species of otter is representing, citing both "river otter" and "sea otter" as keywords.
The more common Eurasian otters are between 60cm and 95cm (including tail) while sea otters can be found between 1m to 1.4m (including tail).
So I propose to meet at the middle and set the otter emoji scale to 1m.